### PR TITLE
Implement projectile follow state

### DIFF
--- a/pixeltrench.p8
+++ b/pixeltrench.p8
@@ -42,6 +42,13 @@ function _init()
   cfg.cam_target = active_worm
 
   -- create_projectile(active_worm.x - 6, active_worm.y - 10, 0, 0, 4, 10)
+
+  -- Register and activate game states.  Drawing and update logic are
+  -- delegated to the current state by the statemachine module.
+  statemachine:add("play", play_state)
+  statemachine:add("projectileFollow", projectile_follow_state)
+  statemachine:add("endRound", end_round_state)
+  statemachine:switch("play")
 end
 
 function _update60()
@@ -162,34 +169,13 @@ function _update60()
   end
 end
 
+-- Shared world rendering helper used by the central draw routine.
+#include render.lua
+
 function _draw()
-  local cam_x, cam_y = flr(cfg.cam_x - 64 + 0.5), flr(cfg.cam_y - 64 + 0.5)
-  camera(cam_x, cam_y)
-  cls(cfg.bg_col)
-  drawmap_with(cam_x)
-
-  for t in all(teams) do
-    for w in all(t.worms) do
-      local rx, ry = flr(w.x + 0.5), flr(w.y + 0.5)
-      circfill(rx, ry, w.r, w.team.col)
-      if w == active_worm then
-        local aim_x = rx + cos(w.aim_angle) * (w.r + 8)
-        local aim_y = ry + sin(w.aim_angle) * (w.r + 8)
-        circfill(aim_x, aim_y, 1, 14)
-        draw_shoot_progress_bar(w)
-      end
-    end
-  end
-
-  for proj in all(projectiles) do
-    circfill(proj.x, proj.y, proj.r, 11)
-  end
-  draw_damage_nums()
-  camera()
-  circfill(mx, my, 2, 10)
-  if cfg.debug then
-    drawdebug()
-  end
+  -- Show worm UI only while the play state is active.
+  local show_ui = statemachine.active_state == play_state
+  draw_world(show_ui)
 end
 
 __gfx__

--- a/pixeltrench.p8
+++ b/pixeltrench.p8
@@ -52,13 +52,14 @@ function _init()
 end
 
 function _update60()
-  update_projectiles()
-  update_damage_nums()
-  for t in all(teams) do
-    for w in all(t.worms) do
-      update_worm(w, w == active_worm)
-    end
-  end
+  statemachine:update()
+  --update_projectiles()
+  --update_damage_nums()
+  -- for t in all(teams) do
+  --   for w in all(t.worms) do
+  --     update_worm(w, w == active_worm)
+  --   end
+  -- end
   cfg.cam_target = active_worm
   update_cam()
 

--- a/render.lua
+++ b/render.lua
@@ -1,0 +1,60 @@
+-- Generic world rendering utilities shared across states.
+--
+-- The core game loop delegates drawing to a state, but most states
+-- render the same world elements (terrain, worms, projectiles,
+-- damage numbers and optional debug overlays).  This module exposes a
+-- single helper so states can render the world without duplicating
+-- code.
+--
+-- Usage:
+--   draw_world(true)  -- draws world and active worm UI
+--   draw_world(false) -- draws world without UI elements
+function draw_world(show_active_worm_ui)
+  -- camera coordinates snapped to integers to avoid sub-pixel jitter
+  local cam_x = flr(cfg.cam_x - 64 + 0.5)
+  local cam_y = flr(cfg.cam_y - 64 + 0.5)
+  camera(cam_x, cam_y)
+
+  -- clear the screen and draw terrain relative to camera
+  cls(cfg.bg_col)
+  drawmap_with(cam_x)
+
+  -- draw all worms; optionally show UI for the active worm
+  for t in all(teams) do
+    for w in all(t.worms) do
+      local rx = flr(w.x + 0.5)
+      local ry = flr(w.y + 0.5)
+      circfill(rx, ry, w.r, t.col)
+
+      -- UI elements such as aim indicator and power bar are only shown
+      -- when player control is active.
+      if show_active_worm_ui and w == active_worm then
+        local aim_x = rx + cos(w.aim_angle) * (w.r + 8)
+        local aim_y = ry + sin(w.aim_angle) * (w.r + 8)
+        circfill(aim_x, aim_y, 1, 14)
+        draw_shoot_progress_bar(w)
+      end
+    end
+  end
+
+  -- draw all active projectiles
+  for proj in all(projectiles) do
+    circfill(proj.x, proj.y, proj.r, 11)
+  end
+
+  -- floating damage numbers are always rendered
+  draw_damage_nums()
+
+  -- return to screen space for overlays like debug info
+  camera()
+
+  -- crosshair is only useful while the player is aiming
+  if show_active_worm_ui then
+    circfill(mx, my, 2, 10)
+  end
+
+  -- optional debugging overlays
+  if cfg.debug then
+    drawdebug()
+  end
+end

--- a/states/endRound.lua
+++ b/states/endRound.lua
@@ -11,9 +11,13 @@ function end_round_state:enter(params)
   -- TODO: optionally start a countdown to let the world settle.
 end
 
--- TODO: Clean up temporary round data before the next turn begins.
+
 function end_round_state:exit()
-  -- TODO: reset timers or other state here.
+  -- reset any per-round timers or transient state
+  self.delay = 0
+  self.next_worm = nil
+  -- ensure camera targets the active worm for the next state
+  cfg.cam_target = active_worm
 end
 
 -- TODO: Wait for the world to settle, then advance to the next turn.

--- a/states/endRound.lua
+++ b/states/endRound.lua
@@ -1,2 +1,25 @@
--- give the world a little cooldown to see death animations, particles fade etc.
--- if stable - go to play state again
+-- State executed after a projectile has finished its flight.
+-- Gives the world time to settle before the next player's turn.
+-- For now the state only renders the world without player UI.
+
+end_round_state = {}
+
+-- TODO: Called when a projectile has finished and the round ends.
+-- Use this to start any delay timer and prepare the next player.
+function end_round_state:enter(params)
+  -- TODO: capture parameters such as which worm should act next.
+  -- TODO: optionally start a countdown to let the world settle.
+end
+
+-- TODO: Clean up temporary round data before the next turn begins.
+function end_round_state:exit()
+  -- TODO: reset timers or other state here.
+end
+
+-- TODO: Wait for the world to settle, then advance to the next turn.
+function end_round_state:update()
+  -- TODO: update physics if needed and watch for the delay timer expiring.
+  -- TODO: when ready, switch back to the `play` state using
+  --       `statemachine:switch("play")` and pass the next worm.
+  -- TODO: check win/loss conditions before switching back.
+end

--- a/states/play.lua
+++ b/states/play.lua
@@ -16,12 +16,48 @@ function play_state:exit()
   -- TODO: perform cleanup here if necessary.
 end
 
--- TODO: Main update loop for the player's turn.
 function play_state:update()
-  -- TODO: handle input to move and aim the active worm.
-  -- TODO: when the player fires, create a projectile and switch to
-  --       `projectileFollow` via `statemachine:switch`.
-  -- TODO: update world physics and keep the camera centered on the
-  --       active worm.
-end
+  -- update fn modifier and aiming state
+  fn_active = btn(cfg.buttons.fn)
 
+  -- update all worms; only the active worm receives player input
+  for t in all(teams) do
+    for w in all(t.worms) do
+      update_worm(w, w == active_worm)
+    end
+  end
+
+  -- handle shooting charge/release for the active worm
+  local c_worm = active_worm
+  if btn(cfg.buttons.shoot) then
+    c_worm.power = min(c_worm.max_power, c_worm.power + c_worm.power_step)
+    if c_worm.power == c_worm.max_power then
+      -- auto-fire at max power
+      local dx = cos(c_worm.aim_angle) * c_worm.power * 0.3
+      local dy = sin(c_worm.aim_angle) * c_worm.power * 0.3
+      local sx = c_worm.x + cos(c_worm.aim_angle) * (c_worm.r + 1)
+      local sy = c_worm.y + sin(c_worm.aim_angle) * (c_worm.r + 1)
+      create_projectile(sx, sy, dx, dy, 2, 8)
+      c_worm.power = 0
+      statemachine:switch("projectileFollow", { projectile = projectiles[#projectiles] })
+      return
+    end
+  elseif c_worm.power > 0 then
+    -- fire on button release
+    local dx = cos(c_worm.aim_angle) * c_worm.power * 0.3
+    local dy = sin(c_worm.aim_angle) * c_worm.power * 0.3
+    local sx = c_worm.x + cos(c_worm.aim_angle) * (c_worm.r + 1)
+    local sy = c_worm.y + sin(c_worm.aim_angle) * (c_worm.r + 1)
+    create_projectile(sx, sy, dx, dy, 2, 8)
+    c_worm.power = 0
+    statemachine:switch("projectileFollow", { projectile = projectiles[#projectiles] })
+    return
+  end
+
+  -- update transient effects
+  update_damage_nums()
+
+  -- keep camera centered on the active worm
+  cfg.cam_target = active_worm
+  update_cam()
+end

--- a/states/play.lua
+++ b/states/play.lua
@@ -3,15 +3,25 @@
 
 play_state = {}
 
+-- TODO: Called when this state becomes active.
+-- Use this to choose the active worm and set up any per-turn state
+-- such as timers or camera focus.
 function play_state:enter(params)
+  -- TODO: store parameters like the active worm and reset the camera
+  --       to follow it.
 end
 
+-- TODO: Clean up any temporary values before switching away from play.
 function play_state:exit()
+  -- TODO: perform cleanup here if necessary.
 end
 
+-- TODO: Main update loop for the player's turn.
 function play_state:update()
-end
-
-function play_state:draw()
+  -- TODO: handle input to move and aim the active worm.
+  -- TODO: when the player fires, create a projectile and switch to
+  --       `projectileFollow` via `statemachine:switch`.
+  -- TODO: update world physics and keep the camera centered on the
+  --       active worm.
 end
 

--- a/states/projectileFollow.lua
+++ b/states/projectileFollow.lua
@@ -1,2 +1,58 @@
 -- cam follows projectile, worms control disabled
 -- after explosion or out of world bounds, switch to endRound state
+
+-- state responsible for tracking a projectile mid flight.
+-- The state assumes a projectile table instance is provided on enter via
+-- the params table.
+-- While active it:
+--  * keeps the camera centered on the projectile
+--  * updates projectile and world physics
+--  * ignores player controls by updating all worms as inactive
+-- Once the projectile is no longer alive (exploded or out of bounds)
+-- it transitions to the `endRound` state.
+
+projectile_follow_state = {}
+
+function projectile_follow_state:enter(params)
+  -- store a reference to the projectile we should follow
+  -- params is expected to be a table like {projectile = <proj>}
+  -- if no projectile provided we fallback to the last one created
+  self.projectile = params and params.projectile or projectiles[#projectiles]
+  -- ensure camera tracks this projectile
+  cfg.cam_target = self.projectile
+end
+
+function projectile_follow_state:exit()
+  -- when leaving we point the camera back to the active worm
+  cfg.cam_target = active_worm
+end
+
+function projectile_follow_state:update()
+  -- update physics for projectiles and floating damage numbers
+  update_projectiles()
+  update_damage_nums()
+
+  -- update worms without letting the player control them
+  -- by always passing false for the is_active flag
+  for t in all(teams) do
+    for w in all(t.worms) do
+      update_worm(w, false)
+    end
+  end
+
+  -- If the projectile is still alive keep the camera centered on it
+  if self.projectile and self.projectile.alive then
+    cfg.cam_target = self.projectile
+    update_cam()
+
+    -- handle out of world bounds by killing the projectile
+    if self.projectile.x < 0 or self.projectile.x > cfg.world_w
+       or self.projectile.y < 0 or self.projectile.y > cfg.world_h then
+      self.projectile.alive = false
+    end
+  else
+    -- projectile is gone → switch to end of round
+    statemachine:switch("endRound")
+  end
+end
+


### PR DESCRIPTION
## Summary
- Introduce `draw_world` helper to render terrain, worms and projectiles once for all states
- Remove duplicated drawing from states and toggle UI in `_draw` based on active state
- Keep camera locked to active projectile and switch to `endRound` when it disappears
- Provide TODO scaffolding in `play_state` and `end_round_state` to guide further implementation

## Testing
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*
- `apt-get install -y lua5.4` *(fails: Unable to locate package lua5.4)*
- `luac -p states/play.lua states/endRound.lua states/projectileFollow.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6f26fa10832c82ba8f76f4e2f6b7